### PR TITLE
Support for multiple arguments

### DIFF
--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -100,4 +100,25 @@ class MiddlewareTest extends TestCase
 
         $this->call('GET', '/article/2');
     }
+
+    /**
+     * @test
+     */
+    public function it_can_use_multiple_models_from_a_route_that_uses_route_model_binding()
+    {
+        $this->app->make(Gate::class)->define('viewArticles', function ($user, $article, $article2) {
+            return $user->id == $article->id && $article->id != $article2->id;
+        });
+
+        auth()->login(User::find(1));
+
+        $response = $this->call('GET', '/articles/1/2');
+
+        $this->assertEquals('article 1 and article2 2', $response->getContent());
+
+        $this->setExpectedException(HttpException::class);
+
+        $this->call('GET', '/articles/2/1');
+        dd($response->getContent());
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -93,6 +93,11 @@ abstract class TestCase extends Orchestra
             return "article {$article->id}";
         }]);
 
+        Route::model('article2', Article::class);
+        Route::any('/articles/{article}/{article2}', ['middleware' => 'can:viewArticles,article,article2', function ($article, $article2) {
+            return "article {$article->id} and article2 {$article2->id}";
+        }]);
+
         Route::any('/auth/login', function () {
             return 'login page';
         });


### PR DESCRIPTION
In a project we're doing, there will be the need to be able to call a policy with multiple arguments. Right now, there is only support for a single argument. With this pull request, multiple arguments can be used in policies.

The route can be defined with middleware like: `'middleware' => 'can:test,cat,cat2'` Where `cat` and `cat2` are arguments for the route/controller-method.
Both these arguments will be passed (possibly resolved as model-objects) to the policy method `test`.

If the minimum php version is bumped to 5.6, a variadic argument could be used instead of the array_slice(func_get_args) :)
Since laravel (for now) has 5.5.9, I did not use the variadic argument and removed the boundModelName argument from the handle-method.

ps. I also added a little test for this. Is this test good enough?
